### PR TITLE
Fix: Pagination 객체 초기화 문제 해결 및 생성자 수정

### DIFF
--- a/src/main/java/com/study/common/dto/SearchDto.java
+++ b/src/main/java/com/study/common/dto/SearchDto.java
@@ -1,6 +1,6 @@
 package com.study.common.dto;
 
-import com.study.paging.Pagination;
+import com.study.common.paging.Pagination;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/com/study/common/paging/Pagination.java
+++ b/src/main/java/com/study/common/paging/Pagination.java
@@ -1,4 +1,4 @@
-package com.study.paging;
+package com.study.common.paging;
 
 import com.study.common.dto.SearchDto;
 import lombok.Getter;
@@ -14,9 +14,10 @@ public class Pagination {
     private boolean existPrevPage;  // 이전 페이지 존재 여부
     private boolean existNextPage;  // 다음 페이지 존재 여부
 
-    public Pagination(int totalPageCount, SearchDto params) {
+    public Pagination(int totalRecordCount, SearchDto params) {
         if (totalRecordCount > 0) {
             this.totalRecordCount = totalRecordCount;
+            calculation(params);
         }
     }
 

--- a/src/main/java/com/study/common/paging/PagingResponse.java
+++ b/src/main/java/com/study/common/paging/PagingResponse.java
@@ -1,4 +1,4 @@
-package com.study.paging;
+package com.study.common.paging;
 
 import lombok.Getter;
 

--- a/src/main/java/com/study/domain/post/PostController.java
+++ b/src/main/java/com/study/domain/post/PostController.java
@@ -2,13 +2,11 @@ package com.study.domain.post;
 
 import com.study.common.dto.MessageDto;
 import com.study.common.dto.SearchDto;
-import com.study.paging.PagingResponse;
+import com.study.common.paging.PagingResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Controller
 @RequiredArgsConstructor

--- a/src/main/java/com/study/domain/post/PostService.java
+++ b/src/main/java/com/study/domain/post/PostService.java
@@ -1,8 +1,8 @@
 package com.study.domain.post;
 
 import com.study.common.dto.SearchDto;
-import com.study.paging.Pagination;
-import com.study.paging.PagingResponse;
+import com.study.common.paging.Pagination;
+import com.study.common.paging.PagingResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;


### PR DESCRIPTION
- [X] 버그 수정

### 반영 브랜치
develop -> main

### 변경 사항
페이징이 게시글 목록 화면에 제대로 안나타나고, 게시글 번호 수가 음수로 나오는 버그 해결
- Pagination 클래스의 생성자 파라미터를 전체 페이지 수에서 데이터 수로 변경
- 만약 전체 데이터수가 0보다 크면 해당 값을 받아와 할당하고 calculation(페이지 계산 로직 함수)을 호출하도록 생성자 코드 변경. => 생성자에서 이 함수를 호출하지 않아 생긴 버그였음.
- paging 패키지 경로 이동 : com.study.paging -> com.study.common.paging