### PR TITLE
Feat: 이전 페이지 정보 유지 기능 구현 (글 수정 시)

### DIFF
--- a/src/main/java/com/study/domain/post/PostController.java
+++ b/src/main/java/com/study/domain/post/PostController.java
@@ -17,6 +17,23 @@ public class PostController {
 
     private final PostService postService;
 
+    // 사용자에게 메시지를 전달하고, 페이지를 리다이렉트 한다.
+    private String showMessageAndRedirect(final MessageDto params, Model model) {
+        model.addAttribute("params", params);
+        return "common/messageRedirect";
+    }
+
+    // 쿼리 스트링 파라미터를 Map에 담아 반환
+    private Map<String, Object> queryParamsToMap(final SearchDto queryParams) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("page", queryParams.getPage());
+        data.put("recordSize", queryParams.getRecordSize());
+        data.put("pageSize", queryParams.getPageSize());
+        data.put("keyword", queryParams.getKeyword());
+        data.put("searchType", queryParams.getSearchType());
+        return data;
+    }
+
     // 게시글 작성 페이지
     @GetMapping("/post/write.do")
     public String openPostWrite(@RequestParam(value = "id", required = false) final Long id, Model model) {
@@ -53,9 +70,9 @@ public class PostController {
 
     // 기존 게시글 수정
     @PostMapping("/post/update.do")
-    public String updatePost(final PostRequest params, Model model) {
+    public String updatePost(final PostRequest params, final SearchDto queryParams, Model model) {
         postService.updatePost(params);
-        MessageDto message = new MessageDto("게시글 수정이 완료되었습니다.", "/post/list.do", RequestMethod.GET, null);
+        MessageDto message = new MessageDto("게시글 수정이 완료되었습니다.", "/post/list.do", RequestMethod.GET, queryParamsToMap(queryParams));
         return showMessageAndRedirect(message, model);
     }
 
@@ -63,24 +80,7 @@ public class PostController {
     @PostMapping("/post/delete.do")
     public String deletePost(@RequestParam final Long id, final SearchDto queryParams, Model model) {
         postService.deletePost(id);
-        MessageDto message = new MessageDto("게시글 생성이 완료되었습니다.", "/post/list.do", RequestMethod.GET, queryParamsToMap(queryParams));
+        MessageDto message = new MessageDto("게시글 삭제가 완료되었습니다.", "/post/list.do", RequestMethod.GET, queryParamsToMap(queryParams));
         return showMessageAndRedirect(message, model);
-    }
-
-    // 사용자에게 메시지를 전달하고, 페이지를 리다이렉트 한다.
-    private String showMessageAndRedirect(final MessageDto params, Model model) {
-        model.addAttribute("params", params);
-        return "common/messageRedirect";
-    }
-
-    // 쿼리 스트링 파라미터를 Map에 담아 반환
-    private Map<String, Object> queryParamsToMap(final SearchDto queryParams) {
-        Map<String, Object> data = new HashMap<>();
-        data.put("page", queryParams.getPage());
-        data.put("recordSize", queryParams.getRecordSize());
-        data.put("pageSize", queryParams.getPageSize());
-        data.put("keyword", queryParams.getKeyword());
-        data.put("searchType", queryParams.getSearchType());
-        return data;
     }
 }

--- a/src/main/resources/templates/post/view.html
+++ b/src/main/resources/templates/post/view.html
@@ -56,6 +56,7 @@
 
         // 게시글 삭제
         function deletePost() {
+
             const id = [[ ${post.id} ]];
 
             if ( !confirm(id + '번 게시글을 삭제할까요?') ) {
@@ -91,7 +92,6 @@
             queryString.delete('id');
             location.href = '/post/list.do' + '?' + queryString.toString();
         }
-
 
     /*]]>*/
 

--- a/src/main/resources/templates/post/write.html
+++ b/src/main/resources/templates/post/write.html
@@ -50,7 +50,7 @@
             </form>
             <p class="btn_set">
                 <button type="button" id="saveBtn" onclick="savePost();" class="btns btn_st3 btn_mid">저장</button>
-                <a th:href="@{/post/list.do}" class="btns btn_bdr3 btn_mid">뒤로</a>
+                <button type="button" onclick="goListPage();" class="btns btn_bdr3 btn_mid">뒤로</button>
             </p>
         </section>
     </div> <!--/* .content */-->
@@ -100,10 +100,25 @@
                 isValid(fields[i], fieldNames[i]);
             }
 
+            new URLSearchParams(location.search).forEach((value, key) => {
+                const input = document.createElement('input');
+                input.type = 'hidden';
+                input.name = key;
+                input.value = value;
+                form.append(input);
+            })
+
             document.getElementById('saveBtn').disabled = true;
             form.noticeYn.value = form.isNotice.checked;
             form.action = [[ ${post == null} ]] ? '/post/save.do' : '/post/update.do';
             form.submit();
+        }
+
+        // 게시글 리스트 페이지로 이동
+        function goListPage() {
+            const queryString = new URLSearchParams(location.search);
+            queryString.delete('id');
+            location.href = '/post/list.do' + '?' + queryString.toString();
         }
 
         /*]]>*/


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가

### 반영 브랜치
develop -> main

### 변경 사항
이전 페이지 정보 유지 기능 구현
- 글 수정 시
- write.html 에서 뒤로 가기 버튼에 onclick 이벤트로 goListPage() 함수 (이전에 검색했던 파라미터 유지한 채 리스트 페이지로 이동)가 실행되도록 변경
