### PR TITLE
Feat: 댓글 목록 조회/ 수정 기능 구현

### DIFF
--- a/src/main/java/com/study/domain/comment/CommentApiController.java
+++ b/src/main/java/com/study/domain/comment/CommentApiController.java
@@ -1,10 +1,9 @@
 package com.study.domain.comment;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,4 +17,12 @@ public class CommentApiController {
         Long id = commentService.saveComment(params);
         return commentService.findCommentById(id);
     }
+
+    // 댓글 목록 조회
+    @GetMapping("/posts/{postId}/comments")
+    public List<CommentResponse> findAllComment(@PathVariable final Long postId) {
+        return commentService.findAllComment(postId);
+    }
+
+
 }

--- a/src/main/java/com/study/domain/comment/CommentApiController.java
+++ b/src/main/java/com/study/domain/comment/CommentApiController.java
@@ -24,5 +24,17 @@ public class CommentApiController {
         return commentService.findAllComment(postId);
     }
 
+    // 댓글 상세정보 조회
+    @GetMapping("/posts/{postId}/comments/{id}")
+    public CommentResponse findCommentById(@PathVariable final Long postId, @PathVariable final Long id) {
+        return commentService.findCommentById(id);
+    }
+
+    // 기존 댓글 수정
+    @PatchMapping("/posts/{postId}/comments/{id}")
+    public CommentResponse updatecomment(@PathVariable final Long postId, @PathVariable final Long id, @RequestBody final CommentRequest params) {
+        commentService.updateComment(params);
+        return commentService.findCommentById(id);
+    }
 
 }

--- a/src/main/resources/templates/post/view.html
+++ b/src/main/resources/templates/post/view.html
@@ -57,6 +57,11 @@
                     </div>
                 </fieldset>
             </div>
+
+            <!--/* 댓글 렌더링 영역 */-->
+            <div class="cm_list">
+
+            </div>
         </section>
     </div> <!--/* .content */-->
 </th:block>
@@ -135,7 +140,62 @@
                 data : JSON.stringify(params),
                 async : false,
                 success : function (response) {
-                    console.log(response);
+                    alert('저장되었습니다.');
+                    content.value = '';
+                    document.getElementById('counter').innerText = '0/300자';
+                    findAllComment();
+                },
+                error : function (request, status, error) {
+                    console.log(error)
+                }
+            })
+        }
+
+        window.onload = () => {
+            findAllComment();
+        }
+
+        // 전체 댓글 조회
+        function findAllComment() {
+
+            const postId = [[ ${post.id} ]];
+
+            $.ajax({
+                url : `/posts/${postId}/comments`,
+                type : 'get',
+                dataType : 'json',
+                async : false,
+                success : function (response) {
+
+                    // 1. 조회된 데이터가 없을 때
+                    if ( !response.length ) {
+                        document.querySelector('.cm_list').innerHTML = '<div class="cm_none"><p>등록된 댓글이 없습니다.</p></div>';
+                        return false;
+                    }
+
+                    // 2. 렌더링 할 HTML을 저장할 변수
+                    let commentHtml = '';
+
+                    // 3. 댓글 HTML 추가
+                    response.forEach(row => {
+                        commentHtml += `
+                            <div>
+                                <span class="writer_img"><img src="/images/default_profile.png" width="30" height="30" alt="기본 프로필 이미지"/></span>
+                                <p class="writer">
+                                    <em>${row.writer}</em>
+                                    <span class="date">${dayjs(row.createdDate).format('YYYY-MM-DD HH:mm')}</span>
+                                </p>
+                                <div class="cont"><div class="txt_con">${row.content}</div></div>
+                                <p class="func_btns">
+                                    <button type="button" class="btns"><span class="icons icon_modify">수정</span></button>
+                                 <button type="button" class="btns"><span class="icons icon_del">삭제</span></button>
+                                </p>
+                            </div>
+                        `;
+                    })
+
+                    // 4. class가 "cm_list"인 요소를 찾아 HTML을 렌더링
+                    document.querySelector('.cm_list').innerHTML = commentHtml;
                 },
                 error : function (request, status, error) {
                     console.log(error)

--- a/src/main/resources/templates/post/view.html
+++ b/src/main/resources/templates/post/view.html
@@ -64,6 +64,33 @@
             </div>
         </section>
     </div> <!--/* .content */-->
+
+    <!--/* 댓글 수정 popup */-->
+    <div id="commentUpdatePopup" class="popLayer">
+        <h3>댓글 수정</h3>
+        <div class="pop_container">
+            <table class="tb tb_row tl">
+                <colgroup>
+                    <col style="width:30%;" /><col style="width:70%;" />
+                </colgroup>
+                <tbody>
+                <tr>
+                    <th scope="row">작성자<span class="es">필수 입력</span></th>
+                    <td><input type="text" id="modalWriter" name="modalWriter" placeholder="작성자를 입력해 주세요." /></td>
+                </tr>
+                <tr>
+                    <th scope="row">내용<span class="es">필수 입력</span></th>
+                    <td><textarea id="modalContent" name="modalContent" cols="90" rows="10" placeholder="수정할 내용을 입력해 주세요."></textarea></td>
+                </tr>
+                </tbody>
+            </table>
+            <p class="btn_set">
+                <button type="button" id="commentUpdateBtn" class="btns btn_st2" onclick="updateComment();">수정</button>
+                <button type="button" class="btns btn_bdr2" onclick="closeCommentUpdatePopup();">취소</button>
+            </p>
+        </div>
+        <button type="button" class="btn_close" onclick="closeCommentUpdatePopup();"><span><i class="far fa-times-circle"></i></span></button>
+    </div>
 </th:block>
 
 <th:block layout:fragment="script">
@@ -187,8 +214,8 @@
                                 </p>
                                 <div class="cont"><div class="txt_con">${row.content}</div></div>
                                 <p class="func_btns">
-                                    <button type="button" class="btns"><span class="icons icon_modify">수정</span></button>
-                                 <button type="button" class="btns"><span class="icons icon_del">삭제</span></button>
+                                    <button type="button" onclick="openCommentUpdatePopup(${row.id});" class="btns"><span class="icons icon_modify">수정</span></button>
+                                    <button type="button" class="btns"><span class="icons icon_del">삭제</span></button>
                                 </p>
                             </div>
                         `;
@@ -203,6 +230,69 @@
             })
         }
 
+    // 댓글 수정 팝업 open
+    function openCommentUpdatePopup(id) {
+
+        const postId = [[ ${post.id} ]];
+
+        $.ajax({
+            url : `/posts/${postId}/comments/${id}`,
+            type : 'get',
+            dataType : 'json',
+            async : false,
+            success : function (response) {
+                document.getElementById('modalWriter').value = response.writer;
+                document.getElementById('modalContent').value = response.content;
+                document.getElementById('commentUpdateBtn').setAttribute('onclick', `updateComment(${id})`);
+                layerPop('commentUpdatePopup');
+            },
+            error : function (request, status, error) {
+                console.log(error)
+            }
+        })
+    }
+
+
+    // 댓글 수정 팝업 close
+    function closeCommentUpdatePopup() {
+        document.querySelectorAll('#modalContent, #modalWriter').forEach(element => element.value = '');
+        document.getElementById('commentUpdateBtn').removeAttribute('onclick');
+        layerPopClose('commentUpdatePopup');
+    }
+
+    // 댓글 수정
+    function updateComment(id) {
+
+        const writer = document.getElementById('modalWriter');
+        const content = document.getElementById('modalContent');
+        isValid(writer, '작성자');
+        isValid(content, '수정할 내용');
+
+        const postId = [[ ${post.id} ]];
+        const params = {
+            id : id,
+            postId : postId,
+            content : content.value,
+            writer : writer.value
+        }
+
+        $.ajax({
+            url : `/posts/${postId}/comments/${id}`,
+            type : 'patch',
+            contentType : 'application/json; charset=utf-8',
+            dataType : 'json',
+            data : JSON.stringify(params),
+            async : false,
+            success : function (response) {
+                alert('수정되었습니다.');
+                closeCommentUpdatePopup();
+                findAllComment();
+            },
+            error : function (request, status, error) {
+                console.log(error)
+            }
+        })
+    }
     /*]]>*/
 
     </script>


### PR DESCRIPTION
### PR 타입
-[X] 기능 추가

### 반영 브랜치
develop -> main

### 변경 사항
- 댓글 목록 조회 기능 구현
   - 특정 게시글에 등록된 댓글 목록 출력 (Ajax 이용한 비동기 방식 -> 어떠한 화면 이동 없이, 등록과 동시에 해당 데이터가 화면에 바로 랜더링됨)
- 댓글 수정 기능 구현
   -  레이어 팝업(모달) 사용
   - 댓글 등록 글자수 실시간으로 카운팅 & 등록 완료 시 글자수 다시 초기화