### PR TITLE
Feat: 댓글 페이징 새로고침 시 페이지 번호 유지

### DIFF
--- a/src/main/java/com/study/domain/comment/CommentRequest.java
+++ b/src/main/java/com/study/domain/comment/CommentRequest.java
@@ -6,8 +6,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-@Setter
-//@NoArgsConstructor(access = AccessLevel.PROTECTED)
+//@Setter  //테스트 더미용
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentRequest {
 
     private Long id;        // 댓글 번호 (PK)

--- a/src/main/resources/templates/post/view.html
+++ b/src/main/resources/templates/post/view.html
@@ -109,8 +109,8 @@
         // 전체 댓글 조회
         function findAllComment(page) {
 
-            const currentPage = document.querySelector('.paging a.on');
-            page = (page) ? page : (currentPage ? Number(currentPage.text) : 1);
+            const uriPage = new URLSearchParams(location.search).get('page');
+            page = (page) ? page : (uriPage ? Number(uriPage) : 1);
 
             const postId = [[ ${post.id}]];
             const uri = `/posts/${postId}/comments`;

--- a/src/main/resources/templates/post/view.html
+++ b/src/main/resources/templates/post/view.html
@@ -327,6 +327,10 @@
             const currentPage = Array.from(paging.querySelectorAll('a')).find(a => (Number(a.text) === page || Number(a.text) === pagination.totalPageCount));
             currentPage.classList.add('on');
             currentPage.removeAttribute('onclick');
+
+            // 8. 페이지 URI 강제 변경
+            const postId = new URLSearchParams(location.search).get('id');
+            history.replaceState({}, '', location.pathname + `?id=${postId}&page=${currentPage.text}`);
         }
     /*]]>*/
 


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가

### 반영 브랜치
develop -> main

### 변경 사항
- 댓글 더미데이터 생성용 setter 주석 처리
- 브라우저의 History API를 이용하여(replaceState()메서드) URI를 강제로 변경해 비동기 페이징 처리의 새로고침 문제 해결