### PR TITLE
Feat: 첨부파일 저장 및 업로드 기능 구현

### DIFF
--- a/src/main/java/com/study/common/file/FileUtils.java
+++ b/src/main/java/com/study/common/file/FileUtils.java
@@ -1,0 +1,108 @@
+package com.study.common.file;
+
+import com.study.domain.file.FileRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class FileUtils {
+
+    private final String uploadPath = Paths.get("C:", "develop", "upload-files").toString();
+
+    /**
+     * 다중 파일 업로드
+     * @param multipartFiles - 파일 객체 List
+     * @return DB에 저장할 파일 정보 List
+     */
+    public List<FileRequest> uploadFiles(final List<MultipartFile> multipartFiles) {
+        List<FileRequest> files = new ArrayList<>();
+        for (MultipartFile multipartFile : multipartFiles) {
+            if (multipartFile.isEmpty()) {
+                continue;
+            }
+            files.add(uploadFile(multipartFile));
+        }
+        return files;
+    }
+
+    /**
+     * 단일 파일 업로드
+     * @param multipartFile - 파일 객체
+     * @return DB에 저장할 파일 정보
+     */
+    public FileRequest uploadFile(final MultipartFile multipartFile) {
+
+        if (multipartFile.isEmpty()) {
+            return null;
+        }
+
+        String saveName = generateSaveFilename(multipartFile.getOriginalFilename());
+        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyMMdd")).toString();
+        String uploadPath = getUploadPath(today) + File.separator + saveName;
+        File uploadFile = new File(uploadPath);
+
+        try {
+            multipartFile.transferTo(uploadFile);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return FileRequest.builder()
+                .originalName(multipartFile.getOriginalFilename())
+                .saveName(saveName)
+                .size(multipartFile.getSize())
+                .build();
+    }
+
+    /**
+     * 저장 파일명 생성
+     * @param filename 원본 파일명
+     * @return 디스크에 저장할 파일명
+     */
+    private String generateSaveFilename(final String filename) {
+        String uuid = UUID.randomUUID().toString().replaceAll("-", "");
+        String extension = StringUtils.getFilenameExtension(filename);
+        return uuid + "." + extension;
+    }
+
+    /**
+     * 업로드 경로 반환
+     * @return 업로드 경로
+     */
+    private String getUploadPath() {
+        return makeDirectories(uploadPath);
+    }
+
+    /**
+     * 업로드 경로 반환
+     * @param addPath - 추가 경로
+     * @return 업로드 경로
+     */
+    private String getUploadPath(final String addPath) {
+        return makeDirectories(uploadPath + File.separator + addPath);
+    }
+
+    /**
+     * 업로드 폴더(디렉터리) 생성
+     * @param path - 업로드 경로
+     * @return 업로드 경로
+     */
+    private String makeDirectories(final String path) {
+        File dir = new File(path);
+        if (dir.exists() == false) {
+            dir.mkdirs();
+        }
+        return dir.getPath();
+    }
+
+}

--- a/src/main/java/com/study/domain/comment/CommentRequest.java
+++ b/src/main/java/com/study/domain/comment/CommentRequest.java
@@ -6,8 +6,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-//@Setter  //테스트 더미용
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter  //테스트 더미용
+//@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentRequest {
 
     private Long id;        // 댓글 번호 (PK)

--- a/src/main/java/com/study/domain/file/FileMapper.java
+++ b/src/main/java/com/study/domain/file/FileMapper.java
@@ -1,0 +1,16 @@
+package com.study.domain.file;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface FileMapper {
+
+    /**
+     * 파일 정보 저장
+     * @param files - 파일 정보 리스트
+     */
+    void saveAll(List<FileRequest> files);
+
+}

--- a/src/main/java/com/study/domain/file/FileRequest.java
+++ b/src/main/java/com/study/domain/file/FileRequest.java
@@ -1,0 +1,50 @@
+package com.study.domain.file;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class FileRequest {
+
+    private Long id;                // 파일 번호 (PK)
+    private Long postId;            // 게시글 번호 (FK)
+    private String originalName;    // 원본 파일명
+    private String saveName;        // 저장 파일명
+    private long size;              // 파일 크기
+
+    @Builder
+    public FileRequest(String originalName, String saveName, long size) {
+        this.originalName = originalName;
+        this.saveName = saveName;
+        this.size = size;
+    }
+
+    public void setPostId(Long postId) {
+        this.postId = postId;
+    }
+
+    /* 객체 생성 시 사용 예시 */
+//    // 일반적인 생성자를 통한 객체 생성
+//    FileRequest fileRequest = new FileRequest("테스트.txt", "abcdeabcde.txt", 10768);
+//
+//    // 빌더 패턴을 통한 객체 생성 1
+//    FileRequest fileRequest = FileRequest.builder()
+//            .originalName("테스트.txt")
+//            .saveName("abcdeabcde.txt")
+//            .size(10768)
+//            .build();
+//
+//    // 빌더 패턴을 통한 객체 생성 2
+//    FileRequest fileRequest = FileRequest.builder()
+//            .size(10768)
+//            .saveName("abcdeabcde.txt")
+//            .originalName("테스트.txt")
+//            .build();
+//
+//    // 빌더 패턴을 통한 객체 생성 3
+//    FileRequest fileRequest = FileRequest.builder()
+//            .saveName("abcdeabcde.txt")
+//            .build();
+
+
+}

--- a/src/main/java/com/study/domain/file/FileService.java
+++ b/src/main/java/com/study/domain/file/FileService.java
@@ -1,0 +1,27 @@
+package com.study.domain.file;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+    private final FileMapper fileMapper;
+
+    @Transactional
+    public void saveFiles(final Long postId, final List<FileRequest> files) {
+        if (CollectionUtils.isEmpty(files)) {
+            return;
+        }
+        for (FileRequest file : files) {
+            file.setPostId(postId);
+        }
+        fileMapper.saveAll(files);
+    }
+
+}

--- a/src/main/java/com/study/domain/post/PostController.java
+++ b/src/main/java/com/study/domain/post/PostController.java
@@ -2,13 +2,17 @@ package com.study.domain.post;
 
 import com.study.common.dto.MessageDto;
 import com.study.common.dto.SearchDto;
+import com.study.common.file.FileUtils;
 import com.study.common.paging.PagingResponse;
+import com.study.domain.file.FileRequest;
+import com.study.domain.file.FileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Controller
@@ -16,6 +20,8 @@ import java.util.Map;
 public class PostController {
 
     private final PostService postService;
+    private final FileService fileService;
+    private final FileUtils fileUtils;
 
     // 사용자에게 메시지를 전달하고, 페이지를 리다이렉트 한다.
     private String showMessageAndRedirect(final MessageDto params, Model model) {
@@ -47,7 +53,9 @@ public class PostController {
     // 새 게시글 생성
     @PostMapping("/post/save.do")
     public String savePost(final PostRequest params, Model model) {
-        postService.savePost(params);
+        Long id = postService.savePost(params);
+        List<FileRequest> files = fileUtils.uploadFiles(params.getFiles());
+        fileService.saveFiles(id, files);
         MessageDto message = new MessageDto("게시글 생성이 완료되었습니다.", "/post/list.do", RequestMethod.GET, null);
         return showMessageAndRedirect(message, model);
     }

--- a/src/main/java/com/study/domain/post/PostRequest.java
+++ b/src/main/java/com/study/domain/post/PostRequest.java
@@ -2,6 +2,10 @@ package com.study.domain.post;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -12,4 +16,5 @@ public class PostRequest {
     private String content;     // 내용
     private String writer;      // 작성자
     private Boolean noticeYn;   // 공지글 여부
+    private List<MultipartFile> files = new ArrayList<>();    // 첨부파일 List
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,7 @@ spring.datasource.hikari.connection-test-query=SELECT NOW() FROM dual
 
 # column name to camel case
 mybatis.configuration.map-underscore-to-camel-case=true
+
+# change upload file size
+spring.servlet.multipart.maxFileSize=10MB
+spring.servlet.multipart.maxRequestSize=50MB

--- a/src/main/resources/mappers/FileMapper.xml
+++ b/src/main/resources/mappers/FileMapper.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.study.domain.file.FileMapper">
+
+    <!-- tb_file 테이블 전체 컬럼 -->
+    <sql id="fileColumns">
+        id
+        , post_id
+        , original_name
+        , save_name
+        , size
+        , delete_yn
+        , created_date
+        , deleted_date
+    </sql>
+
+
+    <!-- 파일 정보 저장 -->
+    <insert id="saveAll" parameterType="list">
+        INSERT INTO tb_file (
+        <include refid="fileColumns" />
+        ) VALUES
+        <foreach item="file" collection="list" separator=",">
+            (
+            #{file.id}
+            , #{file.postId}
+            , #{file.originalName}
+            , #{file.saveName}
+            , #{file.size}
+            , 0
+            , NOW()
+            , NULL
+            )
+        </foreach>
+    </insert>
+
+</mapper>

--- a/src/main/resources/templates/post/write.html
+++ b/src/main/resources/templates/post/write.html
@@ -12,7 +12,7 @@
 
     <div class="content">
         <section>
-            <form id="saveForm" method="post" autocomplete="off">
+            <form id="saveForm" method="post" autocomplete="off" enctype="multipart/form-data">
                 <!--/* 게시글 수정인 경우, 서버로 전달할 게시글 번호 (PK) */-->
                 <input type="hidden" id="id" name="id" th:if="${post != null}" th:value="${post.id}" />
 
@@ -44,6 +44,24 @@
                     <tr>
                         <th>내용 <span class="es">필수 입력</span></th>
                         <td colspan="3"><textarea id="content" name="content" cols="50" rows="10" placeholder="내용을 입력해 주세요."></textarea></td>
+                    </tr>
+
+                    <tr>
+                        <th>첨부파일</th>
+                        <td colspan="3">
+                            <div class="file_list">
+                                <div>
+                                    <div class="file_input">
+                                        <input type="text" readonly />
+                                        <label> 첨부파일
+                                            <input type="file" name="files" onchange="selectFile(this);" />
+                                        </label>
+                                    </div>
+                                    <button type="button" onclick="removeFile(this);" class="btns del_btn"><span>삭제</span></button>
+                                    <button type="button" onclick="addFile();" class="btns fn_add_btn"><span>파일 추가</span></button>
+                                </div>
+                            </div>
+                        </td>
                     </tr>
                     </tbody>
                 </table>
@@ -119,6 +137,59 @@
             const queryString = new URLSearchParams(location.search);
             queryString.delete('id');
             location.href = '/post/list.do' + '?' + queryString.toString();
+        }
+
+        // 파일 선택
+        function selectFile(element) {
+
+            const file = element.files[0];
+            const filename = element.closest('.file_input').firstElementChild;
+
+            // 1. 파일 선택 창에서 취소 버튼이 클릭된 경우
+            if ( !file ) {
+                filename.value = '';
+                return false;
+            }
+
+            // 2. 파일 크기가 10MB를 초과하는 경우
+            const fileSize = Math.floor(file.size / 1024 / 1024);
+            if (fileSize > 10) {
+                alert('10MB 이하의 파일로 업로드해 주세요.');
+                filename.value = '';
+                element.value = '';
+                return false;
+            }
+
+            // 3. 파일명 지정
+            filename.value = file.name;
+        }
+
+
+        // 파일 추가
+        function addFile() {
+            const fileDiv = document.createElement('div');
+            fileDiv.innerHTML =`
+            <div class="file_input">
+                <input type="text" readonly />
+                <label> 첨부파일
+                    <input type="file" name="files" onchange="selectFile(this);" />
+                </label>
+            </div>
+            <button type="button" onclick="removeFile(this);" class="btns del_btn"><span>삭제</span></button>
+        `;
+            document.querySelector('.file_list').appendChild(fileDiv);
+        }
+
+
+        // 파일 삭제
+        function removeFile(element) {
+            const fileAddBtn = element.nextElementSibling;
+            if (fileAddBtn) {
+                const inputs = element.previousElementSibling.querySelectorAll('input');
+                inputs.forEach(input => input.value = '')
+                return false;
+            }
+            element.parentElement.remove();
         }
 
         /*]]>*/


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop -> main

### 변경 사항
- 게시글 업로드 시 첨부파일도 같이 저장 및 업로드되는 기능 구현
   - 다중 파일 업로드를 위해 파일 테이블 따로 생성
   - 파일 저장 로직은 꼭 게시글 저장 로직 뒤에 작성되어야 함. (게시글 저장 실패 했는데 파일이 등록 되어버리면 안되기 때문에)
   - 게시글 작성 화면에 파일 등록, 삭제하는 영역 추가